### PR TITLE
Add SkyLink API

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@
 ## APIs
 - [AirportDB](https://airportdb.io) - This is a JSON database that contains about 60k airports with their runways, communication frequencies, navaids, countries, and regions information.
 - [OpenAIP](https://www.openaip.net) - Free Worldwide Aviation Database
+- [SkyLink API](https://skylinkapi.com/) `FREE/PAID` - All-in-one aviation REST API: ADS-B, NOTAMs, aerodrome charts, carbon estimates, and ML flight-time prediction.
 
 ## Multi Tools
 - [flylog](https://flylog.io)


### PR DESCRIPTION
## Add SkyLink API

### What it is
SkyLink API is an all-in-one aviation data REST API. Right now if you're
building anything aviation related you usually end up wiring together a
tracker for live traffic, a separate provider for charts, another source
for NOTAMs, and yet another for emissions. SkyLink puts all of that behind
one API with consistent JSON, so you integrate once instead of four times.

### The endpoints I think are most useful here
- **Live ADS-B traffic.** Real time aircraft positions, altitude, speed and
  heading. Good for maps and traffic awareness features.
- **Aerodrome charts.** Approach, departure and airport diagrams for 90+
  countries, which saves you from chasing down a bunch of national AIP
  sources separately.
- **NOTAMs.** Queryable Notices to Air Missions for flight planning.
- **Carbon emissions.** Per flight CO2 estimates, handy for travel apps or
  any sustainability reporting.
- **ML flight time estimator.** A model based flight time prediction between
  airports rather than a plain great circle guess.
- It also covers the usual aircraft, airline and airport reference data plus
  historical flight lookups.

### Why it fits awesome-flying
It sits nicely alongside what's already on the list (the trackers, logbooks
and METAR/NOTAM bots), and the charts and carbon endpoints cover a few gaps
I didn't see anything for yet. There's a free tier so people can try it for
hobby projects, with paid plans for heavier use.

Happy to adjust the wording or move it to a different section if you'd
prefer it somewhere else.